### PR TITLE
feat: add falcon-e and other bitnet support

### DIFF
--- a/mlx_lm/quant/utils.py
+++ b/mlx_lm/quant/utils.py
@@ -3,7 +3,14 @@
 from pathlib import Path
 
 import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_unflatten
 
+from ..models.bitlinear_layers import BitLinear
+
+QUANT_LINEAR_MAPPING = {
+    'bitnet': BitLinear,
+}
 
 def load_data(tokenizer, num_samples: int, sequence_length: int) -> mx.array:
     save_dir = Path.home() / ".cache/mlx-lm/calibration_v5.txt"
@@ -24,3 +31,23 @@ def load_data(tokenizer, num_samples: int, sequence_length: int) -> mx.array:
     if num_samples > 0:
         segments = segments[:num_samples]
     return tokens[segments]
+
+def replace_linear_with_quant_linear(model, quant_method = "bitnet", modules_to_not_convert=None):
+    quantize_layers = []
+    for name, module in model.named_modules():     
+        if modules_to_not_convert is None:
+            modules_to_not_convert = []
+        
+        # Replace nn.Linear layers, but skip 'lm_head'
+        if name not in modules_to_not_convert and isinstance(module, nn.Linear):
+            old_weight = module.weight
+            out_features, in_features = old_weight.shape
+            bias = "bias" in module
+            # Create a new instance of the custom linear layer
+            new_layer = QUANT_LINEAR_MAPPING[quant_method](in_features, out_features, bias=bias, invert_weight_scales=True)
+
+            # Replace the layer in the model
+            quantize_layers.append((name, new_layer))
+    if len(quantize_layers) > 0:
+        model.update_modules(tree_unflatten(quantize_layers))
+    return model

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -10,13 +10,8 @@ import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
 
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
-from ..models.bitlinear_layers import BitLinear
 from .dora import DoRAEmbedding, DoRALinear
 from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
-
-QUANT_LINEAR_MAPPING = {
-    'bitnet': BitLinear,
-}
 
 def build_schedule(schedule_config: Dict):
     """
@@ -291,23 +286,3 @@ def print_trainable_parameters(model):
         f"Trainable parameters: {(trainable_p * 100 / total_p):.3f}% "
         f"({trainable_p:.3f}M/{total_p:.3f}M)"
     )
-
-def replace_linear_with_quant_linear(model, quant_method = "bitnet", modules_to_not_convert=None):
-    quantize_layers = []
-    for name, module in model.named_modules():     
-        if modules_to_not_convert is None:
-            modules_to_not_convert = []
-        
-        # Replace nn.Linear layers, but skip 'lm_head'
-        if name not in modules_to_not_convert and isinstance(module, nn.Linear):
-            old_weight = module.weight
-            out_features, in_features = old_weight.shape
-            bias = "bias" in module
-            # Create a new instance of the custom linear layer
-            new_layer = QUANT_LINEAR_MAPPING[quant_method](in_features, out_features, bias=bias, invert_weight_scales=True)
-
-            # Replace the layer in the model
-            quantize_layers.append((name, new_layer))
-    if len(quantize_layers) > 0:
-        model.update_modules(tree_unflatten(quantize_layers))
-    return model

--- a/mlx_lm/tuner/utils.py
+++ b/mlx_lm/tuner/utils.py
@@ -10,9 +10,13 @@ import mlx.optimizers as opt
 from mlx.utils import tree_flatten, tree_unflatten
 
 from ..models.switch_layers import QuantizedSwitchLinear, SwitchLinear
+from ..models.bitlinear_layers import BitLinear
 from .dora import DoRAEmbedding, DoRALinear
 from .lora import LoRAEmbedding, LoRALinear, LoRASwitchLinear
 
+QUANT_LINEAR_MAPPING = {
+    'bitnet': BitLinear,
+}
 
 def build_schedule(schedule_config: Dict):
     """
@@ -287,3 +291,23 @@ def print_trainable_parameters(model):
         f"Trainable parameters: {(trainable_p * 100 / total_p):.3f}% "
         f"({trainable_p:.3f}M/{total_p:.3f}M)"
     )
+
+def replace_linear_with_quant_linear(model, quant_method = "bitnet", modules_to_not_convert=None):
+    quantize_layers = []
+    for name, module in model.named_modules():     
+        if modules_to_not_convert is None:
+            modules_to_not_convert = []
+        
+        # Replace nn.Linear layers, but skip 'lm_head'
+        if name not in modules_to_not_convert and isinstance(module, nn.Linear):
+            old_weight = module.weight
+            out_features, in_features = old_weight.shape
+            bias = "bias" in module
+            # Create a new instance of the custom linear layer
+            new_layer = QUANT_LINEAR_MAPPING[quant_method](in_features, out_features, bias=bias, invert_weight_scales=True)
+
+            # Replace the layer in the model
+            quantize_layers.append((name, new_layer))
+    if len(quantize_layers) > 0:
+        model.update_modules(tree_unflatten(quantize_layers))
+    return model

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -42,7 +42,7 @@ from .tuner.utils import dequantize as dequantize_model
 from .tuner.utils import get_total_parameters, load_adapters
 
 # Quant imports
-from .tuner.utils import replace_linear_with_quant_linear
+from .quant.utils import replace_linear_with_quant_linear
 
 # Constants
 MODEL_REMAPPING = {

--- a/mlx_lm/utils.py
+++ b/mlx_lm/utils.py
@@ -41,6 +41,9 @@ from .tokenizer_utils import TokenizerWrapper, load_tokenizer
 from .tuner.utils import dequantize as dequantize_model
 from .tuner.utils import get_total_parameters, load_adapters
 
+# Quant imports
+from .tuner.utils import replace_linear_with_quant_linear
+
 # Constants
 MODEL_REMAPPING = {
     "mistral": "llama",  # mistral is compatible with llama
@@ -50,6 +53,9 @@ MODEL_REMAPPING = {
 
 MAX_FILE_SIZE_GB = 5
 
+SUPPORTED_HF_QUANTIZATIONS = [
+    "bitnet"
+]
 
 def _get_classes(config: dict):
     """
@@ -159,6 +165,7 @@ def load_model(
     config = load_config(model_path)
     config.update(model_config)
 
+
     weight_files = glob.glob(str(model_path / "model*.safetensors"))
 
     if not weight_files:
@@ -181,8 +188,8 @@ def load_model(
     if hasattr(model, "sanitize"):
         weights = model.sanitize(weights)
 
+    # This handles the case where we use MLX-related quantizations
     if (quantization := config.get("quantization", None)) is not None:
-
         def class_predicate(p, m):
             # Handle custom per layer quantizations
             if p in config["quantization"]:
@@ -198,6 +205,19 @@ def load_model(
             bits=quantization["bits"],
             class_predicate=class_predicate,
         )
+    # We can also handle HF-related quant models such as bitnet
+    elif config.get("quantization_config", None) is not None:
+        quantization_config = config["quantization_config"]
+        quant_method = quantization_config.get("quant_method", None)
+        modules_to_not_convert = quantization_config.get("modules_to_not_convert", None)
+
+        if quant_method is not None and quant_method in SUPPORTED_HF_QUANTIZATIONS:
+            # Replace linear layers with quantized versions
+            model = replace_linear_with_quant_linear(
+                model, 
+                quant_method=quant_method, 
+                modules_to_not_convert=modules_to_not_convert
+            )
 
     model.load_weights(list(weights.items()), strict=strict)
 


### PR DESCRIPTION
As per title and discussion in https://github.com/ml-explore/mlx-lm/pull/219

This PR adds the support for other BitNet models and not limited to Falcon-E

Old Bitnet versions use inverted scales -> this is the main change in bitnet linear layer

@Blaizzy 
