### PR TITLE
Add Gemma 4 Fixes

### DIFF
--- a/mlx_lm/models/gemma4.py
+++ b/mlx_lm/models/gemma4.py
@@ -43,9 +43,13 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        per_layer_inputs: Optional[mx.array] = None,
     ):
         return self.language_model(
-            inputs, cache=cache, input_embeddings=input_embeddings
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
         )
 
     def sanitize(self, weights):
@@ -66,10 +70,14 @@ class Model(nn.Module):
         new_weights.pop("embed_vision", None)
 
         if "language_model" in new_weights:
-            # HF language_model maps to Gemma4TextModel directly (no lm_head wrapper),
-            # but our Model wraps it in self.model, so prepend "model." to each key
+            # Converted MLX weights already use "model.layers.*" while raw HF
+            # checkpoints use "layers.*" under language_model.
             lm_weights = dict(tree_flatten(new_weights["language_model"]))
-            lm_weights = {"model." + k: v for k, v in lm_weights.items()}
+            if not any(
+                k.startswith("model.") or k.startswith("lm_head.")
+                for k in lm_weights
+            ):
+                lm_weights = {"model." + k: v for k, v in lm_weights.items()}
             lm_weights = self.language_model.sanitize(lm_weights)
             new_weights["language_model"] = tree_unflatten(list(lm_weights.items()))
             return dict(tree_flatten(new_weights))

--- a/mlx_lm/models/gemma4.py
+++ b/mlx_lm/models/gemma4.py
@@ -74,8 +74,7 @@ class Model(nn.Module):
             # checkpoints use "layers.*" under language_model.
             lm_weights = dict(tree_flatten(new_weights["language_model"]))
             if not any(
-                k.startswith("model.") or k.startswith("lm_head.")
-                for k in lm_weights
+                k.startswith("model.") or k.startswith("lm_head.") for k in lm_weights
             ):
                 lm_weights = {"model." + k: v for k, v in lm_weights.items()}
             lm_weights = self.language_model.sanitize(lm_weights)

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -448,6 +448,7 @@ class DecoderLayer(nn.Module):
 
         return h
 
+
 class ScaledLinear(nn.Module):
     """Linear layer with output scaling."""
 
@@ -530,7 +531,9 @@ class Gemma4TextModel(nn.Module):
                 counts = matches.sum(axis=1)
                 matched_rows = counts > 0
                 if matched_rows.any():
-                    resolved[matched_rows] = start + matches.argmax(axis=1)[matched_rows]
+                    resolved[matched_rows] = (
+                        start + matches.argmax(axis=1)[matched_rows]
+                    )
                 match_counts += counts
 
             if not np.all(match_counts == 1):

--- a/mlx_lm/models/gemma4_text.py
+++ b/mlx_lm/models/gemma4_text.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import KVCache, RotatingKVCache, _BaseCache
+from .rope_utils import initialize_rope
 
 
 class _OffsetCache(_BaseCache):
@@ -251,13 +253,12 @@ class Attention(nn.Module):
         layer_key = "sliding_attention" if self.is_sliding else "full_attention"
         rope_params = config.rope_parameters.get(layer_key, {})
         rope_theta = rope_params.get("rope_theta", 10000.0)
-        partial_rotary_factor = rope_params.get("partial_rotary_factor", 1.0)
-        rope_dims = int(self.head_dim * partial_rotary_factor)
-
-        self.rope = nn.RoPE(
-            rope_dims,
+        self.rope = initialize_rope(
+            dims=self.head_dim,
             traditional=config.rope_traditional,
             base=rope_theta,
+            scaling_config=rope_params,
+            max_position_embeddings=config.max_position_embeddings,
         )
 
         # KV sharing (2B/4B models)
@@ -447,7 +448,6 @@ class DecoderLayer(nn.Module):
 
         return h
 
-
 class ScaledLinear(nn.Module):
     """Linear layer with output scaling."""
 
@@ -499,7 +499,49 @@ class Gemma4TextModel(nn.Module):
             self.per_layer_model_projection = None
             self.per_layer_projection_norm = None
 
-    def get_per_layer_inputs(self, input_ids: mx.array) -> mx.array:
+    def get_per_layer_inputs(
+        self,
+        input_ids: Optional[mx.array],
+        input_embeddings: Optional[mx.array] = None,
+    ) -> mx.array:
+        if input_ids is None:
+            if input_embeddings is None:
+                raise RuntimeError(
+                    "input_embeddings must be provided when input_ids are omitted."
+                )
+
+            flat_inputs = input_embeddings.reshape(-1, input_embeddings.shape[-1])
+            resolved = np.full((flat_inputs.shape[0],), -1, dtype=np.int32)
+            match_counts = np.zeros((flat_inputs.shape[0],), dtype=np.int32)
+
+            # Reverse the exact embedding lookup in chunks to avoid allocating
+            # a full [batch, seq, vocab, hidden] comparison tensor.
+            chunk_size = 1024
+            for start in range(0, self.config.vocab_size, chunk_size):
+                end = min(start + chunk_size, self.config.vocab_size)
+                vocab_ids = mx.arange(start, end, dtype=mx.int32)
+                vocab_embeddings = self.embed_tokens(vocab_ids)
+                matches = np.array(
+                    mx.all(
+                        flat_inputs[:, None, :] == vocab_embeddings[None, :, :],
+                        axis=-1,
+                    )
+                )
+                counts = matches.sum(axis=1)
+                matched_rows = counts > 0
+                if matched_rows.any():
+                    resolved[matched_rows] = start + matches.argmax(axis=1)[matched_rows]
+                match_counts += counts
+
+            if not np.all(match_counts == 1):
+                raise RuntimeError(
+                    "Could not uniquely recover input_ids from input_embeddings."
+                )
+
+            input_ids = mx.array(
+                resolved.reshape(input_embeddings.shape[:2]), dtype=mx.int32
+            )
+
         result = self.embed_tokens_per_layer(input_ids)
         result = result * self.embed_tokens_per_layer_scale
         return result.reshape(
@@ -531,18 +573,20 @@ class Gemma4TextModel(nn.Module):
         inputs: mx.array = None,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        per_layer_inputs: Optional[mx.array] = None,
     ):
         if input_embeddings is not None:
-            h = input_embeddings
+            raw_input_embeddings = input_embeddings
         else:
-            h = self.embed_tokens(inputs)
+            raw_input_embeddings = self.embed_tokens(inputs)
 
+        h = raw_input_embeddings
         h = h * self.embed_scale
-
-        per_layer_inputs = None
         if self.hidden_size_per_layer_input:
-            if inputs is not None:
-                per_layer_inputs = self.get_per_layer_inputs(inputs)
+            if per_layer_inputs is None:
+                per_layer_inputs = self.get_per_layer_inputs(
+                    inputs, raw_input_embeddings
+                )
             per_layer_inputs = self.project_per_layer_inputs(h, per_layer_inputs)
 
         if cache is None:
@@ -619,8 +663,14 @@ class Model(nn.Module):
         inputs: mx.array,
         cache=None,
         input_embeddings: Optional[mx.array] = None,
+        per_layer_inputs: Optional[mx.array] = None,
     ):
-        out = self.model(inputs, cache, input_embeddings)
+        out = self.model(
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
         if self.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -248,11 +248,17 @@ class ProportionalRoPE(nn.Module):
         )
 
         left = mx.concatenate(
-            [rotated[..., : self.rotated_dims // 2], left[..., self.rotated_dims // 2 :]],
+            [
+                rotated[..., : self.rotated_dims // 2],
+                left[..., self.rotated_dims // 2 :],
+            ],
             axis=-1,
         )
         right = mx.concatenate(
-            [rotated[..., self.rotated_dims // 2 :], right[..., self.rotated_dims // 2 :]],
+            [
+                rotated[..., self.rotated_dims // 2 :],
+                right[..., self.rotated_dims // 2 :],
+            ],
             axis=-1,
         )
         head = mx.concatenate([left, right], axis=-1)

--- a/mlx_lm/models/rope_utils.py
+++ b/mlx_lm/models/rope_utils.py
@@ -196,6 +196,72 @@ class YarnRoPE(nn.Module):
         )
 
 
+class ProportionalRoPE(nn.Module):
+    def __init__(
+        self,
+        dims: int,
+        traditional: bool = False,
+        base: float = 10000.0,
+        scaling_config: Optional[dict] = None,
+    ):
+        super().__init__()
+        self.dims = dims
+        self.traditional = traditional
+
+        scaling_config = scaling_config or {}
+        factor = scaling_config.get("factor", 1.0)
+        partial_rotary_factor = scaling_config.get("partial_rotary_factor", 1.0)
+
+        rope_angles = int(partial_rotary_factor * dims // 2)
+        self.rotated_dims = 2 * rope_angles
+
+        if self.rotated_dims > 0:
+            exponents = mx.arange(0, self.rotated_dims, 2, dtype=mx.float32) / dims
+            self._freqs = factor * (base**exponents)
+        else:
+            self._freqs = None
+
+    def __call__(self, x, offset=0):
+        if self.rotated_dims <= 0:
+            return x
+
+        head = x[..., : self.dims]
+        tail = x[..., self.dims :]
+        half = self.dims // 2
+
+        # Hugging Face proportional RoPE applies rotary embedding to the first
+        # `rope_angles` dimensions of each half, not a contiguous prefix.
+        left = head[..., :half]
+        right = head[..., half:]
+        rotated = mx.concatenate(
+            [left[..., : self.rotated_dims // 2], right[..., : self.rotated_dims // 2]],
+            axis=-1,
+        )
+        rotated = mx.fast.rope(
+            rotated,
+            self.rotated_dims,
+            traditional=self.traditional,
+            base=None,
+            scale=1.0,
+            offset=offset,
+            freqs=self._freqs,
+        )
+
+        left = mx.concatenate(
+            [rotated[..., : self.rotated_dims // 2], left[..., self.rotated_dims // 2 :]],
+            axis=-1,
+        )
+        right = mx.concatenate(
+            [rotated[..., self.rotated_dims // 2 :], right[..., self.rotated_dims // 2 :]],
+            axis=-1,
+        )
+        head = mx.concatenate([left, right], axis=-1)
+
+        if tail.shape[-1] == 0:
+            return head
+        return mx.concatenate([head, tail], axis=-1)
+
+
 def initialize_rope(
     dims,
     base,
@@ -253,6 +319,13 @@ def initialize_rope(
             ],
             short_factor=scaling_config["short_factor"],
             long_factor=scaling_config["long_factor"],
+        )
+    elif rope_type == "proportional":
+        return ProportionalRoPE(
+            dims=dims,
+            traditional=traditional,
+            base=base,
+            scaling_config=scaling_config,
         )
     elif rope_type == "mrope":
         mrope_section = scaling_config.get("mrope_section", [])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -267,7 +267,12 @@ class TestModels(unittest.TestCase):
             freqs=expected_freqs,
         )
         expected = mx.concatenate(
-            [expected_rotated[..., :4], x[..., 4:8], expected_rotated[..., 4:], x[..., 12:]],
+            [
+                expected_rotated[..., :4],
+                x[..., 4:8],
+                expected_rotated[..., 4:],
+                x[..., 12:],
+            ],
             axis=-1,
         )
         mx.eval(y, expected)
@@ -682,13 +687,17 @@ class TestModels(unittest.TestCase):
             }
         )
         self.assertIn(mlx_norm_key, converted)
-        self.assertNotIn("language_model.model.model.layers.0.input_layernorm.weight", converted)
+        self.assertNotIn(
+            "language_model.model.model.layers.0.input_layernorm.weight", converted
+        )
         self.assertTrue(mx.array_equal(converted[mlx_norm_key], base))
         self.assertFalse(any("vision_tower" in k for k in converted))
 
         loaded = model.sanitize({mlx_norm_key: base})
         self.assertIn(mlx_norm_key, loaded)
-        self.assertNotIn("language_model.model.model.layers.0.input_layernorm.weight", loaded)
+        self.assertNotIn(
+            "language_model.model.model.layers.0.input_layernorm.weight", loaded
+        )
         self.assertTrue(mx.array_equal(loaded[mlx_norm_key], base))
 
     def test_gemma4_raw_hf_language_model_prefixes_model(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -242,6 +242,37 @@ class TestModels(unittest.TestCase):
         )
         self.assertTrue(isinstance(rope, rope_utils.Llama3RoPE))
 
+        rope = rope_utils.initialize_rope(
+            16,
+            base=100.0,
+            traditional=False,
+            scaling_config={
+                "rope_type": "proportional",
+                "partial_rotary_factor": 0.5,
+            },
+        )
+        self.assertTrue(isinstance(rope, rope_utils.ProportionalRoPE))
+        expected_freqs = 100.0 ** (mx.arange(0, 8, 2, dtype=mx.float32) / 16)
+        self.assertTrue(mx.allclose(rope._freqs, expected_freqs))
+
+        x = mx.arange(16, dtype=mx.float32).reshape(1, 1, 1, 16)
+        y = rope(x, offset=1)
+        expected_rotated = mx.fast.rope(
+            mx.concatenate([x[..., :4], x[..., 8:12]], axis=-1),
+            8,
+            traditional=False,
+            base=None,
+            scale=1.0,
+            offset=1,
+            freqs=expected_freqs,
+        )
+        expected = mx.concatenate(
+            [expected_rotated[..., :4], x[..., 4:8], expected_rotated[..., 4:], x[..., 12:]],
+            axis=-1,
+        )
+        mx.eval(y, expected)
+        self.assertTrue(mx.allclose(y, expected))
+
     def test_su_scaled_rope_no_mutation(self):
         rope = rope_utils.SuScaledRoPE(
             dims=8,
@@ -611,6 +642,90 @@ class TestModels(unittest.TestCase):
             self.assertTrue(
                 mx.array_equal(loaded[mlx_norm_key], converted[mlx_norm_key])
             )
+
+    def test_gemma4_convert_then_load_keeps_language_model_prefix(self):
+        from mlx_lm.models import gemma4
+
+        args = gemma4.ModelArgs.from_dict(
+            {
+                "model_type": "gemma4",
+                "vocab_size": 32,
+                "text_config": {
+                    "model_type": "gemma4_text",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 8,
+                    "global_head_dim": 8,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "layer_types": ["full_attention"],
+                    "hidden_size_per_layer_input": 0,
+                    "num_kv_shared_layers": 0,
+                    "tie_word_embeddings": True,
+                },
+            }
+        )
+        model = gemma4.Model(args)
+
+        base = mx.arange(8, dtype=mx.float32)
+        hf_norm_key = "model.language_model.model.layers.0.input_layernorm.weight"
+        mlx_norm_key = "language_model.model.layers.0.input_layernorm.weight"
+
+        converted = model.sanitize(
+            {
+                hf_norm_key: base,
+                "model.vision_tower.stub": mx.zeros((1,), dtype=mx.float32),
+            }
+        )
+        self.assertIn(mlx_norm_key, converted)
+        self.assertNotIn("language_model.model.model.layers.0.input_layernorm.weight", converted)
+        self.assertTrue(mx.array_equal(converted[mlx_norm_key], base))
+        self.assertFalse(any("vision_tower" in k for k in converted))
+
+        loaded = model.sanitize({mlx_norm_key: base})
+        self.assertIn(mlx_norm_key, loaded)
+        self.assertNotIn("language_model.model.model.layers.0.input_layernorm.weight", loaded)
+        self.assertTrue(mx.array_equal(loaded[mlx_norm_key], base))
+
+    def test_gemma4_raw_hf_language_model_prefixes_model(self):
+        from mlx_lm.models import gemma4
+
+        args = gemma4.ModelArgs.from_dict(
+            {
+                "model_type": "gemma4",
+                "vocab_size": 32,
+                "text_config": {
+                    "model_type": "gemma4_text",
+                    "hidden_size": 8,
+                    "num_hidden_layers": 1,
+                    "intermediate_size": 16,
+                    "num_attention_heads": 1,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 8,
+                    "global_head_dim": 8,
+                    "sliding_window": 8,
+                    "sliding_window_pattern": 1,
+                    "layer_types": ["full_attention"],
+                    "hidden_size_per_layer_input": 0,
+                    "num_kv_shared_layers": 0,
+                    "tie_word_embeddings": True,
+                },
+            }
+        )
+        model = gemma4.Model(args)
+
+        base = mx.arange(8, dtype=mx.float32)
+        hf_norm_key = "model.language_model.layers.0.input_layernorm.weight"
+        mlx_norm_key = "language_model.model.layers.0.input_layernorm.weight"
+
+        converted = model.sanitize({hf_norm_key: base})
+        self.assertIn(mlx_norm_key, converted)
+        self.assertTrue(mx.array_equal(converted[mlx_norm_key], base))
 
     def test_qwen2_moe(self):
         from mlx_lm.models import qwen2_moe
@@ -1276,6 +1391,87 @@ class TestModels(unittest.TestCase):
         model = gemma4_text.Model(args)
         self.model_test_runner(
             model, args.model_type, args.vocab_size, args.num_hidden_layers
+        )
+
+    def test_gemma4_quantized_embedding_preserves_lookup_scale(self):
+        from mlx_lm.models import gemma4_text
+
+        args = gemma4_text.ModelArgs(
+            model_type="gemma4_text",
+            hidden_size=32,
+            num_hidden_layers=1,
+            intermediate_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_global_key_value_heads=1,
+            head_dim=16,
+            global_head_dim=16,
+            sliding_window=8,
+            sliding_window_pattern=1,
+            layer_types=["full_attention"],
+            hidden_size_per_layer_input=0,
+            vocab_size=4,
+            num_kv_shared_layers=0,
+        )
+        model = gemma4_text.Gemma4TextModel(args)
+        model.embed_tokens.weight = mx.ones((4, 32), dtype=mx.float32)
+        model.embed_tokens = model.embed_tokens.to_quantized(group_size=32, bits=8)
+
+        token_ids = mx.array([[0, 1]], dtype=mx.int32)
+        lookup = model.embed_tokens(token_ids) * model.embed_scale
+        logits = model.embed_tokens.as_linear(mx.ones((1, 1, 32), dtype=mx.float32))
+        mx.eval(lookup, logits)
+
+        self.assertTrue(
+            mx.allclose(
+                lookup,
+                mx.ones((1, 2, 32), dtype=mx.float32) * (32.0**0.5),
+            )
+        )
+        self.assertTrue(
+            mx.allclose(logits, mx.ones((1, 1, 4), dtype=mx.float32) * 32.0)
+        )
+
+    def test_gemma4_input_embeddings_reconstruct_per_layer_inputs(self):
+        from mlx_lm.models import gemma4_text
+
+        args = gemma4_text.ModelArgs(
+            model_type="gemma4_text",
+            hidden_size=32,
+            num_hidden_layers=2,
+            intermediate_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_global_key_value_heads=1,
+            head_dim=16,
+            global_head_dim=16,
+            sliding_window=8,
+            sliding_window_pattern=1,
+            layer_types=["full_attention", "full_attention"],
+            hidden_size_per_layer_input=8,
+            vocab_size=32,
+            vocab_size_per_layer_input=32,
+            num_kv_shared_layers=0,
+        )
+        model = gemma4_text.Model(args)
+        tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
+        embeddings = model.model.embed_tokens(tokens)
+        per_layer_inputs = model.model.get_per_layer_inputs(tokens)
+
+        direct = model(tokens)
+        from_embeddings = model(None, input_embeddings=embeddings)
+        explicit = model(
+            None,
+            input_embeddings=embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
+        mx.eval(direct, from_embeddings, explicit)
+
+        self.assertTrue(
+            mx.allclose(direct.astype(mx.float32), from_embeddings.astype(mx.float32))
+        )
+        self.assertTrue(
+            mx.allclose(direct.astype(mx.float32), explicit.astype(mx.float32))
         )
 
     def test_gpt_bigcode(self):


### PR DESCRIPTION
Standard codex-generated warning applies here - this was done by having codex verify KL against pytorch ref and having it hunt down implementation bugs. I take full responsibility for all code generated.

List of changes:
- gemma4.py (line 55): Fixed to distinguish language_model.layers from already-converted language_model.model.layers - this makes directly converting from `google/gemma-4-31B-it` viable.
- changes gemma4_text to use a new ProportionalRope class w/ proper head-rotation (instead of rotating prefix of head, rotate r/2 dims of left half, r/2 dims of right half)
- adds additional support for input_embeddings so token ids can be recovered (does this by exact matching input_embeddings, inefficient but this is only for the path where you call an E2B/E4B model with input_embeddings only - this is an extreme edge case). 
- adds tests for all these.