### PR TITLE
perf(deepseek_v4): use mx.fast.rms_norm in HyperConnection and HyperHead

### DIFF
--- a/mlx_lm/models/deepseek_v4.py
+++ b/mlx_lm/models/deepseek_v4.py
@@ -649,15 +649,9 @@ def _hc_expand_op(
 
 
 @mx.compile
-def _rms_rsqrt(flat: mx.array, eps: float) -> mx.array:
-    return mx.rsqrt((flat * flat).mean(axis=-1, keepdims=True) + eps)
-
-
-@mx.compile
 def _hc_mixes(flat: mx.array, fn_T: mx.array, norm_eps: float) -> mx.array:
-    """Fused RMS-rsqrt + matmul + scale into single compiled graph."""
-    rsqrt = mx.rsqrt((flat * flat).mean(axis=-1, keepdims=True) + norm_eps)
-    return (flat @ fn_T) * rsqrt
+    """Fused RMS-norm + matmul: rms_norm(flat) @ fn_T."""
+    return mx.fast.rms_norm(flat, None, eps=norm_eps) @ fn_T
 
 
 class HyperConnection(nn.Module):
@@ -679,11 +673,7 @@ class HyperConnection(nn.Module):
         flat = x.reshape(B, L, H * D).astype(mx.float32)
         if self._fn_T is None:
             self._fn_T = self.fn.T
-        if self.training:
-            rsqrt = _rms_rsqrt(flat, self.norm_eps)
-            mixes = (flat @ self._fn_T) * rsqrt
-        else:
-            mixes = _hc_mixes(flat, self._fn_T, self.norm_eps)
+        mixes = _hc_mixes(flat, self._fn_T, self.norm_eps)
         split_sinkhorn = _hc_split_sinkhorn_ops if self.training else hc_split_sinkhorn
         return split_sinkhorn(
             mixes,
@@ -753,8 +743,7 @@ def _hyper_head_op(
     """Fused HyperHead: RMS-rsqrt + matmul + sigmoid + weighted sum."""
     B, L, H, D = x.shape
     flat = x.reshape(B, L, H * D).astype(mx.float32)
-    rsqrt = mx.rsqrt((flat * flat).mean(axis=-1, keepdims=True) + norm_eps)
-    mixes = (flat @ fn.T) * rsqrt
+    mixes = mx.fast.rms_norm(flat, None, eps=norm_eps) @ fn.T
     pre = mx.sigmoid(mixes * scale[0] + base) + hc_eps
     return (pre[..., None] * x.astype(mx.float32)).sum(axis=2).astype(x.dtype)
 
@@ -778,8 +767,7 @@ class HyperHead(nn.Module):
             )
         B, L, H, D = x.shape
         flat = x.reshape(B, L, H * D).astype(mx.float32)
-        rsqrt = _rms_rsqrt(flat, self.norm_eps)
-        mixes = (flat @ self.fn.T) * rsqrt
+        mixes = mx.fast.rms_norm(flat, None, eps=self.norm_eps) @ self.fn.T
         pre = mx.sigmoid(mixes * self.scale[0] + self.base) + self.hc_eps
         return (pre[..., None] * x.astype(mx.float32)).sum(axis=2).astype(x.dtype)
 


### PR DESCRIPTION
## Summary

Replaces the manual `rsqrt(mean(x²) + eps)` + scaled matmul pattern in `HyperConnection` and `HyperHead` with `mx.fast.rms_norm`, which dispatches a fused Metal kernel.

- Removes `_rms_rsqrt` helper (subsumed)
- `_hc_mixes`: `(flat @ fn_T) * rsqrt` → `mx.fast.rms_norm(flat, None, eps) @ fn_T`
- `_hyper_head_op`: same rewrite
- `HyperConnection.compute_weights` training path: unified with inference path (both now go through `_hc_mixes`)
- `HyperHead.__call__` training path: same rewrite

The identity `(x @ W) * s = rms_norm(x) @ W` holds because `s = 1/rms(x)` is a per-row scalar, so it distributes over matrix multiplication.

## Perf

Measured on M-series (DeepSeek-V4 geometry: HC=4, D=7168, flat_dim=28672):

| kernel | baseline | optimised | speedup |
|---|---|---|---|
| `_hc_mixes`   (B=2 L=256) | 0.77 ms | 0.63 ms | **1.22×** |
| `_hyper_head` (B=2 L=256) | 0.72 ms | 0.63 ms | **1.14×** |

Verified numerically with [phew-mlx](https://pypi.org/project/phew-mlx/) equivalence checker (`SubstitutionClass.normed_matmul`, atol=1e-3).