### PR TITLE
[Deepseek] Attempt to fix IndexError on batching.

### DIFF
--- a/mlx_lm/models/deepseek_v4.py
+++ b/mlx_lm/models/deepseek_v4.py
@@ -1224,6 +1224,13 @@ class DeepseekV4Cache:
         self._pending_lengths = None
 
     def filter(self, batch_indices):
+        if isinstance(batch_indices, mx.array):
+            idx_list = batch_indices.tolist()
+        else:
+            idx_list = list(batch_indices)
+        needed = max(idx_list) + 1 if idx_list else 0
+        self._expand_state_to(needed)
+
         if hasattr(self.local, "filter"):
             self.local.filter(batch_indices)
         elif self.local.keys is not None:
@@ -1236,6 +1243,31 @@ class DeepseekV4Cache:
                     state[key] = value[batch_indices]
             for key in self._length_keys:
                 state[key] = self._filter_lengths(state[key], batch_indices)
+
+    def _expand_state_to(self, batch_size: int):
+        """Ensure compressor/indexer state arrays/lists have at least `batch_size`
+        rows along dim 0. Slots without emitted positions are zero-padded."""
+        for state in (self.compressor_state, self.indexer_state):
+            for key in self._state_keys:
+                value = state[key]
+                if value is None:
+                    continue
+                cur = value.shape[0]
+                if cur < batch_size:
+                    pad_shape = (batch_size - cur,) + value.shape[1:]
+                    state[key] = mx.concatenate(
+                        [value, mx.zeros(pad_shape, dtype=value.dtype)], axis=0
+                    )
+            for key in self._length_keys:
+                lst = state[key]
+                if lst is None:
+                    continue
+                if isinstance(lst, mx.array):
+                    lst = lst.tolist()
+                if len(lst) < batch_size:
+                    state[key] = lst + [0] * (batch_size - len(lst))
+                else:
+                    state[key] = lst
 
     def extend(self, other):
         self_batch = self._cache_batch_size(self.local)


### PR DESCRIPTION
Draft for discussion, this workaround was suggested by Claude but I'm not sure it addresses the root cause.

Reproduction:

```bash
mlx_lm.evaluate --model models/DeepSeek-V4-Flash --task mmlu_pro
```

(where `models/DeepSeek-V4-Flash` is just a copy of https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash with the chat template)

---

Stack trace:

```
raceback (most recent call last):ng 3/12032 ...
  File "/Users/pedro/code/deepseek/.venv/bin/mlx_lm.evaluate", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/evaluate.py", line 489, in main
    results = lm_eval.simple_evaluate(
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/.venv/lib/python3.12/site-packages/lm_eval/utils.py", line 498, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/.venv/lib/python3.12/site-packages/lm_eval/evaluator.py", line 366, in simple_evaluate
    results = evaluate(
              ^^^^^^^^^
  File "/Users/pedro/code/deepseek/.venv/lib/python3.12/site-packages/lm_eval/utils.py", line 498, in _wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/.venv/lib/python3.12/site-packages/lm_eval/evaluator.py", line 595, in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/evaluate.py", line 348, in generate_until
    completions = batch_generate(
                  ^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/generate.py", line 1934, in batch_generate
    while responses := gen.next_generated():
                       ^^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/generate.py", line 1866, in next_generated
    prompt_responses, generation_responses = self._next()
                                             ^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/generate.py", line 1809, in _next
    gen_batch = self._prompt_batch.split(split).generate(last_inputs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/generate.py", line 1100, in split
    self.filter(indices_left)
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/generate.py", line 1111, in filter
    c.filter(keep)
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/models/deepseek_v4.py", line 1238, in filter
    state[key] = self._filter_lengths(state[key], batch_indices)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pedro/code/deepseek/prince/mlx-lm/mlx_lm/models/deepseek_v4.py", line 1046, in _filter_lengths
    return [int(lengths[idx]) for idx in batch_indices]
                ~~~~~~~^^^^^
IndexError: list index out of range
```