### PR TITLE
Fix PoolingCache storage

### DIFF
--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -467,6 +467,12 @@ def generate_step(
             break
         yield y.item(), logprobs
         if n % 256 == 0:
+            # Materialize cache state to break the lazy graph chain.
+            # Without this, per-step view rebinds (e.g. PoolingCache's
+            # `self.pooled = self._buf[:, :new_len]`) accumulate as
+            # graph nodes for the entire decode, eventually exhausting
+            # Metal's per-command-buffer resource limit on long runs.
+            mx.eval([c.state for c in prompt_cache])
             mx.clear_cache()
         y, logprobs = next_y, next_logprobs
         n += 1

--- a/mlx_lm/generate.py
+++ b/mlx_lm/generate.py
@@ -1786,6 +1786,7 @@ class BatchGenerator:
             self._gen_tokens_counter += len(generation_responses)
             self._steps_counter += 1
             if self._steps_counter % 512 == 0:
+                mx.eval([c.state for c in self._generation_batch.prompt_cache])
                 mx.clear_cache()
 
         # Exit early because we already have our hands full with decoding

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -908,6 +908,8 @@ class PoolingCache(_BaseCache):
       2. A small remainder buffer of tokens not yet forming a full window.
     """
 
+    step = 256
+
     def __init__(self, ratio: int):
         self.ratio = ratio
 
@@ -915,6 +917,12 @@ class PoolingCache(_BaseCache):
         self.buf_gate = None
         self.remainder = 0
 
+        # The pool is appended to on every call. Resizing to fit each chunk
+        # would issue an mx.concatenate per call, piling up lazy-graph nodes
+        # until Metal's per-command-buffer resource limit crashes long runs.
+        # Instead, self._buf is the storage (grown in self.step chunks) and
+        # self.pooled is a logical-size view; mutation sites keep them in sync.
+        self._buf = None
         self.pooled = None
 
     @property
@@ -984,15 +992,25 @@ class PoolingCache(_BaseCache):
             return r_kv, r_gate, r_base
 
     def update_and_fetch(self, px: mx.array):
-        if px.shape[1] == 0:
+        B, N, D = px.shape
+        if N == 0:
             if self.pooled is None:
-                return mx.zeros((px.shape[0], 0, px.shape[-1]), dtype=px.dtype)
+                return mx.zeros((B, 0, D), dtype=px.dtype)
             return self.pooled
 
-        if self.pooled is None:
-            self.pooled = px
-        else:
-            self.pooled = mx.concatenate([self.pooled, px], axis=1)
+        cur = 0 if self.pooled is None else self.pooled.shape[1]
+        new_len = cur + N
+
+        if self._buf is None:
+            cap = ((new_len + self.step - 1) // self.step) * self.step
+            self._buf = mx.zeros((B, cap, D), dtype=px.dtype)
+        elif self._buf.shape[1] < new_len:
+            cap = ((new_len + self.step - 1) // self.step) * self.step
+            pad = mx.zeros((B, cap - self._buf.shape[1], D), dtype=px.dtype)
+            self._buf = mx.concatenate([self._buf, pad], axis=1)
+
+        self._buf[:, cur:new_len] = px
+        self.pooled = self._buf[:, :new_len]
         return self.pooled
 
     def make_mask(self, L: int = 1, offset: int = 0):
@@ -1025,6 +1043,7 @@ class PoolingCache(_BaseCache):
         if buf_kv is not None:
             self.accumulate_windows(buf_kv, buf_gate, 0)
         self.pooled = pooled
+        self._buf = pooled
 
     @property
     def meta_state(self):
@@ -1065,6 +1084,8 @@ class PoolingCache(_BaseCache):
 class BatchPoolingCache(_BaseCache):
     """Batched pooling cache with per-element variable-length tracking."""
 
+    step = 256
+
     def __init__(self, ratio: int, left_padding: List[int]):
         self.ratio = ratio
 
@@ -1077,6 +1098,8 @@ class BatchPoolingCache(_BaseCache):
         self.buf_gate = None
         self.remainder = [0] * batch_size
 
+        # See PoolingCache.__init__.
+        self._buf = None
         self.pooled = None
         self._pool_lengths = [0] * batch_size
 
@@ -1205,19 +1228,22 @@ class BatchPoolingCache(_BaseCache):
 
         max_pool = max(self._pool_lengths) + max_new
 
-        if self.pooled is None:
-            self.pooled = mx.zeros((B, max_pool, D), dtype=px.dtype)
-        elif self.pooled.shape[1] < max_pool:
-            pad = mx.zeros((B, max_pool - self.pooled.shape[1], D), dtype=px.dtype)
-            self.pooled = mx.concatenate([self.pooled, pad], axis=1)
+        if self._buf is None:
+            cap = ((max_pool + self.step - 1) // self.step) * self.step
+            self._buf = mx.zeros((B, cap, D), dtype=px.dtype)
+        elif self._buf.shape[1] < max_pool:
+            cap = ((max_pool + self.step - 1) // self.step) * self.step
+            pad = mx.zeros((B, cap - self._buf.shape[1], D), dtype=px.dtype)
+            self._buf = mx.concatenate([self._buf, pad], axis=1)
 
         for i in range(B):
             nc = new_counts[i]
             if nc > 0:
                 pl = self._pool_lengths[i]
-                self.pooled[i, pl : pl + nc] = px[i, :nc]
+                self._buf[i, pl : pl + nc] = px[i, :nc]
                 self._pool_lengths[i] = pl + nc
 
+        self.pooled = self._buf[:, :max(self._pool_lengths)]
         return self.pooled
 
     def make_mask(self, L: int = 1, offset=0):
@@ -1254,6 +1280,7 @@ class BatchPoolingCache(_BaseCache):
     @state.setter
     def state(self, v):
         self.buf_kv, self.buf_gate, self.pooled = v
+        self._buf = self.pooled
 
     @property
     def meta_state(self):
@@ -1299,6 +1326,7 @@ class BatchPoolingCache(_BaseCache):
             self.buf_gate = self.buf_gate[batch_indices]
         if self.pooled is not None:
             self.pooled = self.pooled[batch_indices]
+            self._buf = self.pooled
 
         self.remainder = [self.remainder[i] for i in idx_list]
         self._pool_lengths = [self._pool_lengths[i] for i in idx_list]
@@ -1372,6 +1400,7 @@ class BatchPoolingCache(_BaseCache):
                     [pad_pool(self.pooled, B1, P1), pad_pool(other.pooled, B2, P2)],
                     axis=0,
                 )
+                self._buf = self.pooled
 
         self.remainder = self.remainder + other.remainder
         self._pool_lengths = self._pool_lengths + other._pool_lengths
@@ -1385,6 +1414,7 @@ class BatchPoolingCache(_BaseCache):
 
         if self.pooled is not None and pl > 0:
             cache.pooled = mx.contiguous(self.pooled[idx : idx + 1, :pl])
+            cache._buf = cache.pooled
 
         if self.buf_kv is not None and r > 0:
             cache.buf_kv = mx.contiguous(self.buf_kv[idx : idx + 1])
@@ -1420,6 +1450,7 @@ class BatchPoolingCache(_BaseCache):
                     ps = c.pooled.shape[1]
                     pooled[i, :ps] = c.pooled[0]
             batch_cache.pooled = pooled
+            batch_cache._buf = pooled
 
         batch_cache._pool_lengths = pool_sizes
         batch_cache.remainder = [c.remainder for c in caches]

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1268,7 +1268,7 @@ class BatchPoolingCache(_BaseCache):
         if isinstance(offset, mx.array):
             query_pos = offset[:, None] + mx.arange(1, L + 1)
         else:
-            query_pos = offset + mx.arange(offset + 1, offset + L + 1)[None]
+            query_pos = offset + mx.arange(1, L + 1)[None]
 
         causal = pool_idx < (query_pos[..., None] // self.ratio)
         mask = causal & valid

--- a/mlx_lm/models/cache.py
+++ b/mlx_lm/models/cache.py
@@ -1072,8 +1072,9 @@ class PoolingCache(_BaseCache):
         total = 0
         if self.buf_kv is not None:
             total += self.buf_kv.nbytes + self.buf_gate.nbytes
-        if self.pooled is not None:
-            total += self.pooled.nbytes
+        pool = self._buf if self._buf is not None else self.pooled
+        if pool is not None:
+            total += pool.nbytes
         return total
 
     @classmethod
@@ -1311,8 +1312,9 @@ class BatchPoolingCache(_BaseCache):
         total = 0
         if self.buf_kv is not None:
             total += self.buf_kv.nbytes + self.buf_gate.nbytes
-        if self.pooled is not None:
-            total += self.pooled.nbytes
+        pool = self._buf if self._buf is not None else self.pooled
+        if pool is not None:
+            total += pool.nbytes
         return total
 
     def filter(self, batch_indices):

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -12,10 +12,12 @@ from mlx_lm.models.base import create_attention_mask, create_causal_mask
 from mlx_lm.models.cache import (
     ArraysCache,
     BatchKVCache,
+    BatchPoolingCache,
     BatchRotatingKVCache,
     CacheList,
     ChunkedKVCache,
     KVCache,
+    PoolingCache,
     QuantizedKVCache,
     RotatingKVCache,
     load_prompt_cache,
@@ -529,6 +531,22 @@ class TestPromptCache(unittest.TestCase):
         self.assertEqual(cache_a.values.shape[0], 5)
         self.assertEqual(cache_a.offset.tolist(), [6, 7, 6, 1, 4])
         self.assertEqual(cache_a.left_padding.tolist(), [2, 1, 2, 7, 4])
+
+    def test_batch_pooling_cache_scalar_offset_mask(self):
+        ratio = 4
+        caches = [PoolingCache(ratio), PoolingCache(ratio)]
+        for cache in caches:
+            pooled = mx.zeros((1, 6, 8), dtype=mx.float32)
+            cache.update_and_fetch(pooled)
+
+        batch_cache = BatchPoolingCache.merge(caches)
+        mask = batch_cache.make_mask(L=3, offset=8)
+
+        expected = mx.arange(6)[None] < (
+            8 + mx.arange(1, 4)
+        )[:, None] // ratio
+        self.assertTrue(mx.array_equal(mask[0], expected))
+        self.assertTrue(mx.array_equal(mask[1], expected))
 
     def test_batch_rotating_kv_cache(self):
         cache = BatchRotatingKVCache(max_size=4, left_padding=[2, 0])


### PR DESCRIPTION
Running the server against DeepSeek V4 can crash mid-decode with:

    RuntimeError: [metal::malloc] Resource limit (499000) exceeded.

This appears to be Metal's per-command-buffer resource handle limit, triggered by long-running decode with pooled/compressed cache state.

## Root Cause

DeepSeek V4’s pooled cache is updated repeatedly during decode. Before this change, the pooled cache grew by appending exactly the newly produced pooled tokens each time. Under MLX’s lazy execution model, those repeated cache mutations can leave a long chain of pending graph/state updates attached to the retained cache tensors.

For long generations, that chain can accumulate enough Metal resources to hit the command-buffer resource limit.

There was also a separate bug in `BatchPoolingCache.make_mask()` for scalar offsets. The non-batched offset path double-counted the offset when building prompt-time causal visibility for pooled tokens, which could produce an incorrect pooled attention mask.

## Fix

This PR addresses the issue in three complementary ways:

1. The pooled cache now uses chunked backing storage, matching the allocation strategy used by the other KV caches. This avoids resizing the pooled tensor on every append and reduces allocation churn during long decode.

2. Decode periodically materializes cache state before clearing MLX’s cache. Step allocation reduces the append pressure, but the server repro still needed explicit materialization to break the retained lazy graph chain. The same materialization is applied to both single-request generation and batched generation paths.

3. `BatchPoolingCache.make_mask()` now handles scalar offsets correctly, so pooled prompt masks match the intended causal visibility rule for compressed tokens.

The cache’s byte accounting was also updated so server prompt-cache stats and LRU limits reflect the allocated backing storage, not just the logical view length.

## Tests

- `uv run python -m unittest tests.test_prompt_cache`
- DeepSeek V4 server repro validated manually under sustained decode