### PR TITLE
laguna: windowed KV via make_cache() + strip language_model. prefix

### DIFF
--- a/mlx_lm/models/laguna.py
+++ b/mlx_lm/models/laguna.py
@@ -6,6 +6,7 @@ import mlx.nn as nn
 
 from .activations import swiglu
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .cache import KVCache, RotatingKVCache
 from .rope_utils import initialize_rope
 from .switch_layers import SwitchGLU
 
@@ -406,7 +407,33 @@ class Model(nn.Module):
             return self.model.embed_tokens.as_linear(out)
         return self.lm_head(out)
 
+    def make_cache(self):
+        # Most Laguna layers are sliding_attention: they never attend beyond
+        # their window, so a bounded RotatingKVCache is both correct and far
+        # cheaper than a full cache at long context. Only the full_attention
+        # (global) layers need an unbounded KVCache.
+        caches = []
+        for lt in self.args.layer_types:
+            # A sliding layer needs a valid window; if a (malformed) config
+            # omits sliding_window, fall back to a full cache rather than build
+            # a RotatingKVCache with max_size=None.
+            if lt == "sliding_attention" and self.args.sliding_window:
+                caches.append(RotatingKVCache(max_size=self.args.sliding_window))
+            else:
+                caches.append(KVCache())
+        return caches
+
     def sanitize(self, weights):
+        # Some repacks (e.g. AtomicChat/Laguna-XS-2.1-MLX-8bit) wrap every
+        # tensor under a VLM-style `language_model.` prefix. Strip it so the
+        # keys line up with this module tree (model.* / lm_head.*).
+        if any(k.startswith("language_model.") for k in weights):
+            prefix = "language_model."
+            weights = {
+                (k[len(prefix) :] if k.startswith(prefix) else k): v
+                for k, v in weights.items()
+            }
+
         if self.args.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
 


### PR DESCRIPTION
Hi @Blaizzy — the two small additions I mentioned on ml-explore/mlx-lm#1223, as a ready-to-merge follow-up onto your branch (merging this updates the PR). Both are tested against your current `pc/add-lg` and `black==25.1.0` clean.

**1. `make_cache()` for the sliding-window layers.** The `sliding_attention` layers (the majority) never attend beyond their window, so this returns a bounded `RotatingKVCache(max_size=sliding_window)` for them and a full `KVCache` only for the `full_attention` (global) layers. Without it, `make_prompt_cache` allocates a full cache on all 40 layers — storing/attending over history the sliding layers can't use. Measured ~2.7x decode and ~4 GB less KV at 32k on the 8-bit repack; bitwise-identical to a full cache at ≤ window context. Falls back to a full cache if a config omits `sliding_window`.

**2. `language_model.` prefix strip in `sanitize()`.** Some repacks (e.g. `AtomicChat/Laguna-XS-2.1-MLX-8bit`) wrap every tensor under a VLM-style `language_model.` prefix, so a stock load misses all weights. This strips it up front when present.

Verified locally: `make_cache()` returns the right cache type per `layer_types`, forward + single-step decode run with those caches, and `sanitize()` strips the prefix. Happy to adjust to your preferences, or drop it if you'd rather fold these in yourself.
